### PR TITLE
Add support to frozen types

### DIFF
--- a/lib/ecto_cassandra.ex
+++ b/lib/ecto_cassandra.ex
@@ -610,6 +610,8 @@ defmodule EctoCassandra do
     do: "MAP<text, #{column_type(type)}>"
   defp column_type(:map),
     do: "MAP<text, text>"
+  defp column_type({:frozen, type}),
+    do: "frozen<#{column_type(type)}>"
   defp column_type({:array, type}),
     do: "LIST<#{column_type(type)}>"
   defp column_type({:set, type}),

--- a/test/ecto_cassandra/migration_test.exs
+++ b/test/ecto_cassandra/migration_test.exs
@@ -12,6 +12,7 @@ defmodule EctoCassandra.MigrationTest do
       {:add, :published_at, :timestamp, []},
       {:add, :is_active, :boolean, []},
       {:add, :tags, {:array, :string}, []},
+      {:add, :reservations, {:frozen, {:array, :integer}}, []}
     ]}
 
     assert cql(create) == join """
@@ -22,6 +23,7 @@ defmodule EctoCassandra.MigrationTest do
         published_at timestamp,
         is_active boolean,
         tags LIST<text>,
+        reservations frozen<LIST<int>>,
         PRIMARY KEY (id))
       """
   end


### PR DESCRIPTION
I recently had to interact with a project that makes use of frozen types. This option allows for more complex column types such as `frozen<list<string>>`