### PR TITLE
Updated mix.exs to not include Ecto `2.2`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule EctoCassandra.Mixfile do
   ]
 
   defp deps, do: [
-    {:ecto, "~> 2.1"},
+    {:ecto, "~> 2.1.0"},
     {:cassandra, "~> 1.0.0-rc.1"},
     {:excoveralls, "~> 0.6", only: :test},
     {:ex_doc, ">= 0.0.0", only: :dev},


### PR DESCRIPTION
See issue #13 